### PR TITLE
[1.18] Add keys.name and key_name configuration options

### DIFF
--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -1346,8 +1346,10 @@ class Configuration implements Utils\ClearableState
         } elseif ($this->hasValue($prefix . 'certData')) {
             $certData = $this->getString($prefix . 'certData');
             $certData = preg_replace('/\s+/', '', $certData);
+            $keyName = $this->getString($prefix . 'key_name', NULL);
             return [
                 [
+                    'name'            => $keyName,
                     'encryption'      => true,
                     'signing'         => true,
                     'type'            => 'X509Certificate',
@@ -1373,9 +1375,11 @@ class Configuration implements Utils\ClearableState
                 );
             }
             $certData = preg_replace('/\s+/', '', $matches[1]);
+            $keyName = $this->getString($prefix . 'key_name', NULL);
 
             return [
                 [
+                    'name'            => $keyName,
                     'encryption'      => true,
                     'signing'         => true,
                     'type'            => 'X509Certificate',

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -789,14 +789,15 @@ class SAMLBuilder
      * @param \SAML2\XML\md\RoleDescriptor $rd The RoleDescriptor the certificate should be added to.
      * @param string                      $use The value of the 'use' attribute.
      * @param string                      $x509data The certificate data.
+     * @param string|null                 $keyName The name of the key. Should be valid for usage in an ID attribute, e.g. not start with a digit.
      * @return void
      */
-    private function addX509KeyDescriptor(RoleDescriptor $rd, $use, $x509data)
+    private function addX509KeyDescriptor(RoleDescriptor $rd, string $use, string $x509data, ?string $keyName = null): void
     {
         assert(in_array($use, ['encryption', 'signing'], true));
         assert(is_string($x509data));
 
-        $keyDescriptor = \SAML2\Utils::createKeyDescriptor($x509data);
+        $keyDescriptor = \SAML2\Utils::createKeyDescriptor($x509data, $keyName);
         $keyDescriptor->setUse($use);
         $rd->addKeyDescriptor($keyDescriptor);
     }
@@ -819,10 +820,10 @@ class SAMLBuilder
                 continue;
             }
             if (!isset($key['signing']) || $key['signing'] === true) {
-                $this->addX509KeyDescriptor($rd, 'signing', $key['X509Certificate']);
+                $this->addX509KeyDescriptor($rd, 'signing', $key['X509Certificate'], $key['name'] ?? NULL);
             }
             if (!isset($key['encryption']) || $key['encryption'] === true) {
-                $this->addX509KeyDescriptor($rd, 'encryption', $key['X509Certificate']);
+                $this->addX509KeyDescriptor($rd, 'encryption', $key['X509Certificate'], $key['name'] ?? NULL);
             }
         }
 

--- a/lib/SimpleSAML/Utils/Crypto.php
+++ b/lib/SimpleSAML/Utils/Crypto.php
@@ -284,6 +284,7 @@ class Crypto
                 $certFingerprint = strtolower(sha1(base64_decode($certData)));
 
                 return [
+                    'name'            => $key['name'] ?? NULL,
                     'certData'        => $certData,
                     'PEM'             => $pem,
                     'certFingerprint' => [$certFingerprint],

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -118,6 +118,7 @@ if ($certInfo !== null && array_key_exists('certData', $certInfo)) {
     $certData = $certInfo['certData'];
 
     $keys[] = [
+        'name'            => $certInfo['name'] ?? NULL,
         'type'            => 'X509Certificate',
         'signing'         => true,
         'encryption'      => true,
@@ -132,6 +133,7 @@ if ($certInfo !== null && array_key_exists('certData', $certInfo)) {
     $certData = $certInfo['certData'];
 
     $keys[] = [
+        'name'            => $certInfo['name'] ?? NULL,
         'type'            => 'X509Certificate',
         'signing'         => true,
         'encryption'      => ($hasNewCert ? false : true),
@@ -221,6 +223,9 @@ if ($email && $email !== 'na@example.org') {
 // add certificate
 if (count($keys) === 1) {
     $metaArray20['certData'] = $keys[0]['X509Certificate'];
+    if (isset($keys[0]['name'])) {
+        $metaArray20['key_name'] = $keys[0]['name'];
+    }
 } elseif (count($keys) > 1) {
     $metaArray20['keys'] = $keys;
 }
@@ -262,6 +267,7 @@ $xml = $metaBuilder->getEntityDescriptorText();
 unset($metaArray20['UIInfo']);
 unset($metaArray20['metadata-set']);
 unset($metaArray20['entityid']);
+unset($metaArray20['key_name']);
 
 // sanitize the attributes array to remove friendly names
 if (isset($metaArray20['attributes']) && is_array($metaArray20['attributes'])) {


### PR DESCRIPTION
This is the same as https://github.com/simplesamlphp/simplesamlphp/pull/1509, but for v1.18 of simplesamlphp.

For DVG, we can currently not upgrade to v1.19 because it requires symfony 4 which is not supported by Drupal 8.