### PR TITLE
[1.19] Add keys.name and key_name configuration options (OLD)

### DIFF
--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -1349,8 +1349,10 @@ class Configuration implements Utils\ClearableState
         } elseif ($this->hasValue($prefix . 'certData')) {
             $certData = $this->getString($prefix . 'certData');
             $certData = preg_replace('/\s+/', '', $certData);
+            $keyName = $this->getString($prefix . 'key_name', null);
             return [
                 [
+                    'name'            => $keyName,
                     'encryption'      => true,
                     'signing'         => true,
                     'type'            => 'X509Certificate',
@@ -1376,9 +1378,11 @@ class Configuration implements Utils\ClearableState
                 );
             }
             $certData = preg_replace('/\s+/', '', $matches[1]);
+            $keyName = $this->getString($prefix . 'key_name', null);
 
             return [
                 [
+                    'name'            => $keyName,
                     'encryption'      => true,
                     'signing'         => true,
                     'type'            => 'X509Certificate',

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -793,13 +793,14 @@ class SAMLBuilder
      * @param \SAML2\XML\md\RoleDescriptor $rd The RoleDescriptor the certificate should be added to.
      * @param string                      $use The value of the 'use' attribute.
      * @param string                      $x509data The certificate data.
+     * @param string|null                 $keyName The name of the key. Should be valid for usage in an ID attribute, e.g. not start with a digit.
      * @return void
      */
-    private function addX509KeyDescriptor(RoleDescriptor $rd, string $use, string $x509data): void
+    private function addX509KeyDescriptor(RoleDescriptor $rd, string $use, string $x509data, ?string $keyName = null): void
     {
         assert(in_array($use, ['encryption', 'signing'], true));
 
-        $keyDescriptor = \SAML2\Utils::createKeyDescriptor($x509data);
+        $keyDescriptor = \SAML2\Utils::createKeyDescriptor($x509data, $keyName);
         $keyDescriptor->setUse($use);
         $rd->addKeyDescriptor($keyDescriptor);
     }
@@ -822,10 +823,10 @@ class SAMLBuilder
                 continue;
             }
             if (!isset($key['signing']) || $key['signing'] === true) {
-                $this->addX509KeyDescriptor($rd, 'signing', $key['X509Certificate']);
+                $this->addX509KeyDescriptor($rd, 'signing', $key['X509Certificate'], $key['name'] ?? null);
             }
             if (!isset($key['encryption']) || $key['encryption'] === true) {
-                $this->addX509KeyDescriptor($rd, 'encryption', $key['X509Certificate']);
+                $this->addX509KeyDescriptor($rd, 'encryption', $key['X509Certificate'], $key['name'] ?? null);
             }
         }
 

--- a/lib/SimpleSAML/Utils/Crypto.php
+++ b/lib/SimpleSAML/Utils/Crypto.php
@@ -277,6 +277,7 @@ class Crypto
                 $certFingerprint = strtolower(sha1(base64_decode($certData)));
 
                 return [
+                    'name'            => $key['name'] ?? null,
                     'certData'        => $certData,
                     'PEM'             => $pem,
                     'certFingerprint' => [$certFingerprint],

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -808,6 +808,7 @@ class SAML2
         $hasNewCert = false;
         if ($certInfo !== null) {
             $keys[] = [
+                'name' => $certInfo['name'] ?? null,
                 'type' => 'X509Certificate',
                 'signing' => true,
                 'encryption' => true,
@@ -820,6 +821,7 @@ class SAML2
         /** @var array $certInfo */
         $certInfo = Utils\Crypto::loadPublicKey($config, true);
         $keys[] = [
+            'name' => $certInfo['name'] ?? null,
             'type' => 'X509Certificate',
             'signing' => true,
             'encryption' => $hasNewCert === false,
@@ -831,6 +833,7 @@ class SAML2
             /** @var array $httpsCert */
             $httpsCert = Utils\Crypto::loadPublicKey($config, true, 'https.');
             $keys[] = [
+                'name' => $httpsCert['name'] ?? null,
                 'type' => 'X509Certificate',
                 'signing' => true,
                 'encryption' => false,

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -264,6 +264,7 @@ $xml = $metaBuilder->getEntityDescriptorText();
 unset($metaArray20['UIInfo']);
 unset($metaArray20['metadata-set']);
 unset($metaArray20['entityid']);
+unset($metaArray20['key_name']);
 
 // sanitize the attributes array to remove friendly names
 if (isset($metaArray20['attributes']) && is_array($metaArray20['attributes'])) {


### PR DESCRIPTION
This is the same as https://github.com/simplesamlphp/simplesamlphp/pull/1509, but for v1.19 of simplesamlphp (instead of v2).